### PR TITLE
Skip rollup - Don't actually merge

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ function tryResolve(pkg, importer) {
 		return relative.resolve(pkg, importer);
 	} catch (err) {
 		if (err.code === 'MODULE_NOT_FOUND') return null;
+		if (pkg === 'rollup/package.json') return null
 		throw err;
 	}
 }


### PR DESCRIPTION
This patch fixes my issue #98
I don't really know what it does but it prevents rollup from trying to bundle itself again? Sorry, no clue but this still fixes my issue and might help to get a proper fix so that I can use rollup v2 for my project.

This is not intended for merging but has a nice diff :)